### PR TITLE
Feature/Implement new syntax

### DIFF
--- a/docs/Syntax.md
+++ b/docs/Syntax.md
@@ -9,6 +9,7 @@ Petram is a statically typed language with type inference. It is whitespace-sign
 
 ## Primitive Types
 
+### Atomic Primitive Types
 - `Int`
   - `Int8`, `Int16`, `Int32`, `Int64`
 - `Float`
@@ -16,6 +17,43 @@ Petram is a statically typed language with type inference. It is whitespace-sign
 - `Bool`
 - `String`
 - `Char`
+
+### Compound Primitive Types
+
+- Arrays
+  - Single dimensional: `[]T`
+    - `[]Int` is an array of integers with an unspecified length. You may use this syntax when manually instantiating an array. The length is determined at compile time.
+
+    - ```petra
+    $array_of_strings := ["Hello", "World"] -- [2]String
+    $ints_that_should_be_small: []UInt8 = [1, 2, 3] -- [3]UInt8
+    $I_dont_trust_the_compiler_so_I_will_specify_the_length_manually: [10]Int = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    ```
+
+    - To initialize an array with items, you may use the `[length; value]` syntax.
+
+    - ```petra
+    $array_of_ten_fives: [10]Int = [10; 5] -- [10]Int, specifically, [5, 5, 5, 5, 5, 5, 5, 5, 5, 5]
+    ```
+
+- Multi-dimensional: `[][]T`
+  - `[][]Int` is a 2D array of integers.
+  - When instantiating a multi-dimensional array, as with single-dimensional arrays, the size must be either inferrable or explicitly specified.
+  - Array initialization is done row by row, and works the same as with single-dimensional arrays.
+
+  - ```petra
+    $tictactoe_board: [][]String = [3, 3; " "] -- [3][3]String, specifically, [[" ", " ", " "], [" ", " ", " "], [" ", " ", " "]]
+    ```
+
+- Invalid cases:
+  - You may not use `[]T` to declare a variable. Size must be either inferrable or explicitly specified.
+
+  - ```petra
+    $invalid_array_declaration: []Int -- Error, size is not inferrable
+    ```
+- Accessing items is done via `[]`.
+  - Single-dimensional arrays: `$array[$i]`
+  - Multi-dimensional arrays: `$array[$i, $j, ..., $z]`
 
 ## Variables
 
@@ -143,4 +181,15 @@ func #{greet_user ~> name: String}#: () ->
         Item: 2
         Item: 3
     -}
+    ```
+---
+## Syntax sugar
+
+### Function sugar
+
+- You may end a function name with `?` to indicate a predicate. Its return type is automaticall inferred as `Bool` and you may omit the return type.
+- Use this for short, simple predicates that can fit into a `=>` function.
+
+  - ```petra
+    func #{is_even? ~> n: Int}# => n % 2 == 0
     ```

--- a/docs/Syntax.md
+++ b/docs/Syntax.md
@@ -56,7 +56,7 @@ func #{greet_user ~> name: String}#: () ->
 ```petra
     struct #{StructName}# ->
         constrained field field_name: Type
-        where #{boolean_expression}# message: "Error message"
+            where #{boolean_expression}# message: "Error message"
 
         new #{arg_name: Type}#: Result<Self, String> ->
             @field_name = arg_name
@@ -101,31 +101,46 @@ func #{greet_user ~> name: String}#: () ->
 
 - Pattern matching is an expression and must be enclosed in `#{}#`.
 
-```petra
-$somevar := #{
-    match $something_else ->
-        Pattern1 -> result1
-        Pattern2 -> result2
-        _ -> default_result
-}#
-```
+  - ```petra
+    $somevar := #{
+        match $something_else ->
+            Pattern1 -> result1
+            Pattern2 -> result2
+            _ -> default_result
+        }#
+    ```
+
+
+- Using `match` as a statement is generally discouraged. However, if you wish to, you may use the `_ :=` syntax:
+
+  - ```petra
+    _ := #{
+        match $some_value ->
+            Pattern1 ->
+            #{println ~> message: "Pattern 1"}#
+        Pattern2 ->
+            #{println ~> message: "Pattern 2"}#
+        _ ->
+            #{println ~> message: "Default"}#
+    }#
+    ```
 
 ## Loops
 
 - `foreach` loop:
 
-```petra
--- inferred as List<Int>
-$collection := {|1, 2, 3|}
+  - ```petra
+    -- inferred as List<Int>
+    $collection := {|1, 2, 3|}
 
--- $item is inferred as Int
-foreach $item in $collection ->
-#{println ~> message: "Item: {$item}"}#
+    -- $item is inferred as Int
+    foreach $item in $collection ->
+        #{println ~> message: "Item: {$item}"}#
 
-{-
-Prints:
-Item: 1
-Item: 2
-Item: 3
--}
-```
+    {-
+        Prints:
+        Item: 1
+        Item: 2
+        Item: 3
+    -}
+    ```

--- a/examples/tic_tac_toe.petra
+++ b/examples/tic_tac_toe.petra
@@ -62,21 +62,27 @@ func #{check_winner ~> board: List<List<String>>, player: String}#: Option<Strin
     -- Check rows, columns, and diagonals
     foreach $i in 0..3 ->
         $winner := #{
-            if #{$board[$i][0] == $player && $board[$i][1] == $player && $board[$i][2] == $player ||
-                $board[0][$i] == $player && $board[1][$i] == $player && $board[2][$i] == $player}# ->
-                Option::Some($player)
+            if #{
+                board[$i][0] == player && board[$i][1] == player && board[$i][2] == player ||
+                board[0][$i] == player && board[1][$i] == player && board[2][$i] == player
+            }# ->
+                Option::Some(player)
             else ->
                 Option::None
         }#
-        #{
-            if #{Option::is_none ~> opt: $winner}# == false ->
-                return $winner
+
+        _ := #{
+            match $winner ->
+                None -> None,
+                Some($w) -> return $w
         }#
 
-    #{
-        if #{$board[0][0] == $player && $board[1][1] == $player && $board[2][2] == $player ||
-            $board[0][2] == $player && $board[1][1] == $player && $board[2][0] == $player}# ->
-            Option::Some($player)
+    return #{
+        if #{
+            board[0][0] == player && board[1][1] == player && board[2][2] == player ||
+            board[0][2] == player && board[1][1] == player && board[2][0] == player
+        }# ->
+            Option::Some(player)
         else ->
             Option::None
     }#

--- a/examples/tic_tac_toe.petra
+++ b/examples/tic_tac_toe.petra
@@ -1,15 +1,11 @@
 func #{main ~> args: List<String>}#: () ->
-    $board := #{
-        List<List<String>>::new(3) ~> item: #{
-            List<String>::new(3) ~> item: " "
-        }#
-    }#
+    $board := [3, 3; " "]
     $current_player := "X"
     $winner := Option::None
     $moves := 0
 
     while #{
-        #{Option::is_none ~> opt: $winner}# && $moves < 9
+        $winner.is_none? && $moves < 9
     }# ->
         #{print_board ~> board: $board}#
         $row := #{get_move ~> prompt: "Row (0, 1, or 2): "}#
@@ -17,7 +13,7 @@ func #{main ~> args: List<String>}#: () ->
         
         _ := #{
             if #{valid_move? ~> board: $board, row: $row, col: $col}# ->
-                $board[$row][$col] := $current_player
+                $board[$row, $col] := $current_player
                 $moves := $moves + 1
                 $winner := #{check_winner ~> board: $board, player: $current_player}#
                 $current_player := #{switch_player ~> current_player: $current_player}#
@@ -34,7 +30,7 @@ func #{main ~> args: List<String>}#: () ->
     #{println ~> message: $message}#
 
 -- Helper function to print the board
-func #{print_board ~> board: List<List<String>>}#: () ->
+func #{print_board ~> board: [][]String}#: () ->
     foreach $row in $board ->
         #{println ~> message: " | ".join($row)}#
         #{println ~> message: "---------"}#
@@ -44,9 +40,12 @@ func #{get_move ~> prompt: String}#: Result<Int, String> ->
     $input_val := #{input ~> prompt: $prompt}#
     #{to_int ~> value: $input_val}#
 
--- Helper function to check if a move is valid
-func #{valid_move? ~> board: List<List<String>>, row: Int, col: Int}#: Bool =>
-    #{0 <= $row && $row < 3 && 0 <= $col && $col < 3 && $board[$row][$col] == " "}#
+{-
+    Helper function to check if a move is valid
+    Shows off the `?` sugar by making this a predicate function, implicitly returning a Bool
+-}
+func #{valid_move? ~> board: [][]String, row: Int, col: Int}# =>
+    #{0 <= $row && $row < 3 && 0 <= $col && $col < 3 && $board[$row, $col] == " "}#
 
 -- Helper function to switch between players
 func #{switch_player ~> current_player: String}#: String ->
@@ -58,13 +57,13 @@ func #{switch_player ~> current_player: String}#: String ->
     }#
 
 -- Helper function to check for a winner
-func #{check_winner ~> board: List<List<String>>, player: String}#: Option<String> ->
-    -- Check rows, columns, and diagonals
+func #{check_winner ~> board: [][]String, player: String}#: Option<String> ->
+    -- Check rows, columns first
     foreach $i in 0..3 ->
         $winner := #{
             if #{
-                board[$i][0] == player && board[$i][1] == player && board[$i][2] == player ||
-                board[0][$i] == player && board[1][$i] == player && board[2][$i] == player
+                board[$i, 0] == player && board[$i, 1] == player && board[$i, 2] == player ||
+                board[0, $i] == player && board[1, $i] == player && board[2, $i] == player
             }# ->
                 Option::Some(player)
             else ->
@@ -77,10 +76,11 @@ func #{check_winner ~> board: List<List<String>>, player: String}#: Option<Strin
                 Some($w) -> return $w
         }#
 
+    -- Check diagonals
     return #{
         if #{
-            board[0][0] == player && board[1][1] == player && board[2][2] == player ||
-            board[0][2] == player && board[1][1] == player && board[2][0] == player
+            board[0, 0] == player && board[1, 1] == player && board[2, 2] == player ||
+            board[0, 2] == player && board[1, 1] == player && board[2, 0] == player
         }# ->
             Option::Some(player)
         else ->


### PR DESCRIPTION
This PR adds a draft in the `Syntax.md` document for arrays, which are primitives as opposed to `List<T>`. Additionally, we introduce support for the `funcname?` sugar, which turns a function implicitly into a "predicate" - that is, it implicitly returns a `Bool`. It is best suited for short, concise functions that can be written with the `=>` syntax.

We also tweak `examples/tic-tac-toe.petram` to reflect the new changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new sections in the documentation for "Atomic Primitive Types," "Compound Primitive Types," and "Syntax sugar" to enhance understanding of the Petram programming language.
	- Added examples for array declarations and error handling in the documentation.
  
- **Bug Fixes**
	- Improved clarity and readability in the `tic_tac_toe` example by updating board initialization and element access syntax.

- **Documentation**
	- Enhanced formatting and consistency in the "Variables," "Control Flow," and "Pattern Matching" sections of the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->